### PR TITLE
Remove repo-issue from dependencies.yml

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -6,6 +6,3 @@ collectors:
   # pull requests for updates to our major version
   - type: js-npm
     versions: "L.Y.Y"
-  # create issues for new major versions
-  - type: repo-issue
-    versions: "Y.0.0"


### PR DESCRIPTION
Hi @bojanbass! We're poking around failed builds in dependencies.io to root out any problems, and noticed your repos. I assume this repo was maybe forked for testing out dependencies.io, but I thought I'd suggest a change here anyway. The "repo-issue" actor is failing because issues aren't enabled on this repo. We've got an open issue on our suggested config now to not include that if we can see that issues are turned off.

Anyway, thanks for trying out dependencies.io!